### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "civic-digital-twins"
-version = "0.4.0"
+version = "0.5.0"
 description = "Civic-Digital-Twins Modeling Framework"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This diff bumps the version to v0.5.0. This is a routine change after releasing v0.4.0.