### PR TITLE
fix(README.md): update badge locations after renaming repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Civic-Digital-Twins Modeling Framework
 
-[![Build Status](https://github.com/fbk-most/dt-model/actions/workflows/test.yml/badge.svg)](https://github.com/fbk-most/dt-model/actions) [![codecov](https://codecov.io/gh/fbk-most/dt-model/branch/main/graph/badge.svg)](https://codecov.io/gh/fbk-most/dt-model) [![PyPI version](https://img.shields.io/pypi/v/civic-digital-twins.svg)](https://pypi.org/project/civic-digital-twins/) [![Python Versions](https://img.shields.io/pypi/pyversions/civic-digital-twins.svg)](https://pypi.org/project/civic-digital-twins/) [![License](https://img.shields.io/pypi/l/civic-digital-twins.svg)](https://pypi.org/project/civic-digital-twins/)
+[![Build Status](https://github.com/fbk-most/civic-digital-twins/actions/workflows/test.yml/badge.svg)](https://github.com/fbk-most/civic-digital-twins/actions) [![codecov](https://codecov.io/gh/fbk-most/civic-digital-twins/branch/main/graph/badge.svg)](https://codecov.io/gh/fbk-most/civic-digital-twins) [![PyPI version](https://img.shields.io/pypi/v/civic-digital-twins.svg)](https://pypi.org/project/civic-digital-twins/) [![Python Versions](https://img.shields.io/pypi/pyversions/civic-digital-twins.svg)](https://pypi.org/project/civic-digital-twins/) [![License](https://img.shields.io/pypi/l/civic-digital-twins.svg)](https://pypi.org/project/civic-digital-twins/)
 
 This repository contains a Python package implementing a Civic-Digital-Twins
 modeling framework. The framework is designed to support defining digital
@@ -38,6 +38,10 @@ or
 ```Python
 from civic_digital_twins import dt_model
 ```
+
+## Minimum Python Version
+
+Python 3.11.
 
 ## API Stability Guarantees
 


### PR DESCRIPTION
We didn't update the badge locations, which causes some badges to misbehave (see, e.g., the codecov badge).

While there, document the minimum Python version as well.

No functional change.