### PR TITLE
refactor: move compile flags into separate package

### DIFF
--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -1,0 +1,12 @@
+"""
+The compileflags package defines the flags used by the compiler engine.
+
+We centralize the definition of flags to avoid defining flags into each package
+and ending up with incompatible compiler engine flags.
+"""
+
+TRACE = 1 << 0
+"""Indicates that we should trace execution."""
+
+BREAK = 1 << 1
+"""Indicates that we should break execution after evaluation."""

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -112,7 +112,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from .. import atomic
+from .. import atomic, compileflags
 
 Axis = int | tuple[int, ...]
 """Type alias for axis specifications in shape operations."""
@@ -121,10 +121,10 @@ Scalar = bool | float | int
 """Type alias for supported scalar value types."""
 
 
-NODE_FLAG_TRACE = 1 << 0
+NODE_FLAG_TRACE = compileflags.TRACE
 """Inserts a tracepoint at the corresponding graph node."""
 
-NODE_FLAG_BREAK = 1 << 1
+NODE_FLAG_BREAK = compileflags.BREAK
 """Inserts a breakpoint at the corresponding graph node."""
 
 


### PR DESCRIPTION
We are already using compile flags for *both* individual nodes in `./frontend/graph.py` and the `./numpybackend`. This diff refactors the code to centralize the place where we define flags.

No functional change.