### PR TITLE
feat(graph.py): round-trippable SSA node __repr__

### DIFF
--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -82,6 +82,32 @@ Design Decisions
    - Nodes are identified by their instance identity
    - Enables graph traversal and transformation
 
+4. Node Representation:
+    - The __repr__ of a node emits the Python code that would generate the node
+    - Therefore, the __repr__ representation is round-trippable
+
+Node Representation
+-------------------
+
+Given this code:
+
+    a = graph.placeholder("a")
+    b = graph.placeholder("b")
+    c = a + b
+
+If you print each node, you obtain:
+
+    n1 = graph.placeholder(name="a", default_value=None)
+    n2 = graph.placeholder(name="b", default_value=None)
+    n3 = graph.add(left=n1, right=n2, name="")
+
+That is, the `__repr__` (and `__str__`) of each node is an SSA representation
+where you see the node IDs (the format is `nX` where `X` is the ID) and the
+arguments with which they were constructed.
+
+Crucially, if you execute the `__repr__` of each node, you get back the
+same graph that you have constructred with the original code.
+
 Node Identity and Equality
 --------------------------
 
@@ -159,6 +185,9 @@ class Node:
         self.name = name
         self.flags = 0
         self.id = _id_generator.add(1)
+
+    def __str__(self) -> str:
+        return repr(self)  # subclasses define suitable __repr__
 
     def __hash__(self) -> int:
         """Override hash to use identity-based hashing.
@@ -268,6 +297,9 @@ class constant(Node):
         super().__init__(name)
         self.value = value
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.constant(value={self.value}, name='{self.name}')"
+
 
 class placeholder(Node):
     """Named placeholder for a value to be provided during evaluation.
@@ -280,6 +312,9 @@ class placeholder(Node):
     def __init__(self, name: str, default_value: Scalar | None = None) -> None:
         super().__init__(name)
         self.default_value = default_value
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.placeholder(name='{self.name}', default_value={self.default_value})"
 
 
 class BinaryOp(Node):
@@ -302,17 +337,29 @@ class BinaryOp(Node):
 class add(BinaryOp):
     """Element-wise addition of two tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.add(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class subtract(BinaryOp):
     """Element-wise subtraction of two tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.subtract(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 class multiply(BinaryOp):
     """Element-wise multiplication of two tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.multiply(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class divide(BinaryOp):
     """Element-wise division of two tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.divide(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 # Comparison operations
@@ -321,25 +368,43 @@ class divide(BinaryOp):
 class equal(BinaryOp):
     """Element-wise equality comparison of two tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class not_equal(BinaryOp):
     """Element-wise inequality comparison of two tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.not_equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 class less(BinaryOp):
     """Element-wise less-than comparison of two tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.less(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class less_equal(BinaryOp):
     """Element-wise less-than-or-equal comparison of two tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.less_equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 class greater(BinaryOp):
     """Element-wise greater-than comparison of two tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.greater(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class greater_equal(BinaryOp):
     """Element-wise greater-than-or-equal comparison of two tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.greater_equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 # Logical operations
@@ -348,13 +413,22 @@ class greater_equal(BinaryOp):
 class logical_and(BinaryOp):
     """Element-wise logical AND of two boolean tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.logical_and(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class logical_or(BinaryOp):
     """Element-wise logical OR of two boolean tensors."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.logical_or(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
+
 
 class logical_xor(BinaryOp):
     """Element-wise logical XOR of two boolean tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.logical_xor(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 class UnaryOp(Node):
@@ -372,6 +446,9 @@ class UnaryOp(Node):
 class logical_not(UnaryOp):
     """Element-wise logical NOT of a boolean tensor."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.logical_not(node=n{self.node.id}, name='{self.name}')"
+
 
 # Math operations
 
@@ -379,9 +456,15 @@ class logical_not(UnaryOp):
 class exp(UnaryOp):
     """Element-wise exponential of a tensor."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.exp(node=n{self.node.id}, name='{self.name}')"
+
 
 class power(BinaryOp):
     """Element-wise power operation (first tensor raised to power of second)."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.power(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 pow = power
@@ -391,9 +474,15 @@ pow = power
 class log(UnaryOp):
     """Element-wise natural logarithm of a tensor."""
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.log(node=n{self.node.id}, name='{self.name}')"
+
 
 class maximum(BinaryOp):
     """Element-wise maximum of two tensors."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.maximum(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
 # Conditional operations
@@ -414,6 +503,9 @@ class where(Node):
         self.then = then
         self.otherwise = otherwise
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.where(condition=n{self.condition.id}, then=n{self.then.id}, otherwise=n{self.otherwise.id}, name='{self.name}')"
+
 
 class multi_clause_where(Node):
     """Selects elements from tensors based on multiple conditions.
@@ -427,6 +519,10 @@ class multi_clause_where(Node):
         super().__init__(name)
         self.clauses = clauses
         self.default_value = default_value
+
+    def __repr__(self) -> str:
+        clauses = [(f"n{condition.id}", f"n{then.id}") for condition, then in self.clauses]
+        return f"n{self.id} = graph.multi_clause_where(clauses={clauses}, default_value=n{self.default_value}, name='{self.name}')"
 
 
 # Shape-changing operations
@@ -456,9 +552,15 @@ class expand_dims(AxisOp):
     This expands the tensor to a higher-dimensional space.
     """
 
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.expand_dims(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
+
 
 class squeeze(AxisOp):
     """Removes axes of size 1 from a tensor's shape."""
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.squeeze(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 
 class project_using_sum(AxisOp):
@@ -466,6 +568,9 @@ class project_using_sum(AxisOp):
 
     This projects the tensor to a lower-dimensional space.
     """
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.project_using_sum(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 
 reduce_sum = project_using_sum
@@ -479,6 +584,9 @@ class project_using_mean(AxisOp):
 
     This projects the tensor to a lower-dimensional space.
     """
+
+    def __repr__(self) -> str:
+        return f"n{self.id} = graph.project_using_mean(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 
 reduce_mean = project_using_mean

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -565,7 +565,7 @@ class where(Generic[C, T], Node[T]):
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
-        return f"n{self.id} = graph.where(condition=n{self.condition.id}, then=n{self.then.id}, otherwise=n{self.otherwise.id}, name='{self.name}')"
+        return f"n{self.id} = graph.where(condition=n{self.condition.id}, then=n{self.then.id}, otherwise=n{self.otherwise.id}, name='{self.name}')"  # noqa: E501
 
 
 class multi_clause_where(Generic[C, T], Node[T]):
@@ -583,8 +583,8 @@ class multi_clause_where(Generic[C, T], Node[T]):
 
     def __repr__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
-        clauses = [(f"n{condition.id}", f"n{then.id}") for condition, then in self.clauses]
-        return f"n{self.id} = graph.multi_clause_where(clauses={clauses}, default_value=n{self.default_value}, name='{self.name}')"
+        clauses = ", ".join(f"(n{condition.id}, n{then.id})" for condition, then in self.clauses)
+        return f"n{self.id} = graph.multi_clause_where(clauses=[{clauses}], default_value=n{self.default_value.id}, name='{self.name}')"  # noqa: E501
 
 
 # Shape-changing operations

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -139,7 +139,7 @@ where you see the node IDs (the format is `nX` where `X` is the ID) and the
 arguments with which they were constructed.
 
 Crucially, if you execute the `__repr__` of each node, you get back the
-same graph that you have constructred with the original code.
+same graph that you have constructed with the original code.
 
 Node Identity and Equality
 --------------------------

--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -226,6 +226,7 @@ class Node(Generic[T]):
         self.id = _id_generator.add(1)
 
     def __str__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return repr(self)  # subclasses define suitable __repr__
 
     def __hash__(self) -> int:
@@ -337,6 +338,7 @@ class constant(Generic[T], Node[T]):
         self.value = value
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.constant(value={self.value}, name='{self.name}')"
 
 
@@ -353,6 +355,7 @@ class placeholder(Generic[T], Node[T]):
         self.default_value = default_value
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.placeholder(name='{self.name}', default_value={self.default_value})"
 
 
@@ -377,6 +380,7 @@ class add(Generic[T], BinaryOp[T]):
     """Element-wise addition of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.add(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -384,6 +388,7 @@ class subtract(Generic[T], BinaryOp[T]):
     """Element-wise subtraction of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.subtract(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -391,6 +396,7 @@ class multiply(Generic[T], BinaryOp[T]):
     """Element-wise multiplication of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.multiply(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -398,6 +404,7 @@ class divide(Generic[T], BinaryOp[T]):
     """Element-wise division of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.divide(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -408,6 +415,7 @@ class equal(Generic[T], BinaryOp[T]):
     """Element-wise equality comparison of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -415,6 +423,7 @@ class not_equal(Generic[T], BinaryOp[T]):
     """Element-wise inequality comparison of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.not_equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -422,6 +431,7 @@ class less(Generic[T], BinaryOp[T]):
     """Element-wise less-than comparison of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.less(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -429,6 +439,7 @@ class less_equal(Generic[T], BinaryOp[T]):
     """Element-wise less-than-or-equal comparison of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.less_equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -436,6 +447,7 @@ class greater(Generic[T], BinaryOp[T]):
     """Element-wise greater-than comparison of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.greater(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -443,6 +455,7 @@ class greater_equal(Generic[T], BinaryOp[T]):
     """Element-wise greater-than-or-equal comparison of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.greater_equal(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -453,6 +466,7 @@ class logical_and(Generic[T], BinaryOp[T]):
     """Element-wise logical AND of two boolean tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.logical_and(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -460,6 +474,7 @@ class logical_or(Generic[T], BinaryOp[T]):
     """Element-wise logical OR of two boolean tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.logical_or(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -467,6 +482,7 @@ class logical_xor(Generic[T], BinaryOp[T]):
     """Element-wise logical XOR of two boolean tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.logical_xor(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -486,6 +502,7 @@ class logical_not(Generic[T], UnaryOp[T]):
     """Element-wise logical NOT of a boolean tensor."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.logical_not(node=n{self.node.id}, name='{self.name}')"
 
 
@@ -496,6 +513,7 @@ class exp(Generic[T], UnaryOp[T]):
     """Element-wise exponential of a tensor."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.exp(node=n{self.node.id}, name='{self.name}')"
 
 
@@ -503,6 +521,7 @@ class power(Generic[T], BinaryOp[T]):
     """Element-wise power operation (first tensor raised to power of second)."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.power(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -514,6 +533,7 @@ class log(Generic[T], UnaryOp[T]):
     """Element-wise natural logarithm of a tensor."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.log(node=n{self.node.id}, name='{self.name}')"
 
 
@@ -521,6 +541,7 @@ class maximum(Generic[T], BinaryOp[T]):
     """Element-wise maximum of two tensors."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.maximum(left=n{self.left.id}, right=n{self.right.id}, name='{self.name}')"
 
 
@@ -543,6 +564,7 @@ class where(Generic[C, T], Node[T]):
         self.otherwise = otherwise
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.where(condition=n{self.condition.id}, then=n{self.then.id}, otherwise=n{self.otherwise.id}, name='{self.name}')"
 
 
@@ -560,6 +582,7 @@ class multi_clause_where(Generic[C, T], Node[T]):
         self.default_value = default_value
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         clauses = [(f"n{condition.id}", f"n{then.id}") for condition, then in self.clauses]
         return f"n{self.id} = graph.multi_clause_where(clauses={clauses}, default_value=n{self.default_value}, name='{self.name}')"
 
@@ -592,6 +615,7 @@ class expand_dims(Generic[T], AxisOp[T]):
     """
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.expand_dims(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 
@@ -599,6 +623,7 @@ class squeeze(Generic[T], AxisOp[T]):
     """Removes axes of size 1 from a tensor's shape."""
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.squeeze(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 
@@ -609,6 +634,7 @@ class project_using_sum(Generic[T], AxisOp[T]):
     """
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.project_using_sum(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 
@@ -625,6 +651,7 @@ class project_using_mean(Generic[T], AxisOp[T]):
     """
 
     def __repr__(self) -> str:
+        """Return a round-trippable SSA representation of the node."""
         return f"n{self.id} = graph.project_using_mean(node=n{self.node.id}, axis={self.axis}, name='{self.name}')"
 
 

--- a/tests/dt_model/engine/frontend/test_graph.py
+++ b/tests/dt_model/engine/frontend/test_graph.py
@@ -457,3 +457,90 @@ def test_static_type_checking_failure(tmp_path):
     print(result.stdout)  # for debugging
 
     assert result.returncode != 0, "Pyright unexpectedly passed a known type error"
+
+
+def test_repr():
+    """Test we get the correct node __repr__ for each node that has a __repr__."""
+    a = graph.constant(114, name="a")
+    assert str(a) == f"n{a.id} = graph.constant(value=114, name='a')"
+
+    b = graph.placeholder("b", default_value=11)
+    assert str(b) == f"n{b.id} = graph.placeholder(name='b', default_value=11)"
+
+    c = a + b
+    assert str(c) == f"n{c.id} = graph.add(left=n{a.id}, right=n{b.id}, name='')"
+
+    d = a - b
+    assert str(d) == f"n{d.id} = graph.subtract(left=n{a.id}, right=n{b.id}, name='')"
+
+    e = a * b
+    assert str(e) == f"n{e.id} = graph.multiply(left=n{a.id}, right=n{b.id}, name='')"
+
+    f = a / b
+    assert str(f) == f"n{f.id} = graph.divide(left=n{a.id}, right=n{b.id}, name='')"
+
+    g = a == b
+    assert str(g) == f"n{g.id} = graph.equal(left=n{a.id}, right=n{b.id}, name='')"
+
+    h = a != b
+    assert str(h) == f"n{h.id} = graph.not_equal(left=n{a.id}, right=n{b.id}, name='')"
+
+    i = a < b
+    assert str(i) == f"n{i.id} = graph.less(left=n{a.id}, right=n{b.id}, name='')"
+
+    j = a <= b
+    assert str(j) == f"n{j.id} = graph.less_equal(left=n{a.id}, right=n{b.id}, name='')"
+
+    k = a > b
+    assert str(k) == f"n{k.id} = graph.greater(left=n{a.id}, right=n{b.id}, name='')"
+
+    out = a >= b
+    assert str(out) == f"n{out.id} = graph.greater_equal(left=n{a.id}, right=n{b.id}, name='')"
+
+    m = a & b
+    assert str(m) == f"n{m.id} = graph.logical_and(left=n{a.id}, right=n{b.id}, name='')"
+
+    n = a | b
+    assert str(n) == f"n{n.id} = graph.logical_or(left=n{a.id}, right=n{b.id}, name='')"
+
+    o = a ^ b
+    assert str(o) == f"n{o.id} = graph.logical_xor(left=n{a.id}, right=n{b.id}, name='')"
+
+    p = ~a
+    assert str(p) == f"n{p.id} = graph.logical_not(node=n{a.id}, name='')"
+
+    q = graph.exp(a)
+    assert str(q) == f"n{q.id} = graph.exp(node=n{a.id}, name='')"
+
+    r = graph.power(a, b)
+    assert str(r) == f"n{r.id} = graph.power(left=n{a.id}, right=n{b.id}, name='')"
+
+    s = graph.log(a)
+    assert str(s) == f"n{s.id} = graph.log(node=n{a.id}, name='')"
+
+    t = graph.maximum(a, b)
+    assert str(t) == f"n{t.id} = graph.maximum(left=n{a.id}, right=n{b.id}, name='')"
+
+    condition = graph.placeholder("condition")
+    u = graph.where(condition, a, b)
+    assert str(u) == f"n{u.id} = graph.where(condition=n{condition.id}, then=n{a.id}, otherwise=n{b.id}, name='')"
+
+    other_cond = graph.placeholder("other_cond")
+    defval = graph.placeholder("defval")
+    u = graph.multi_clause_where([(condition, a), (other_cond, b)], defval)
+    assert (
+        str(u)
+        == f"n{u.id} = graph.multi_clause_where(clauses=[(n{condition.id}, n{a.id}), (n{other_cond.id}, n{b.id})], default_value=n{defval.id}, name='')"  # noqa: E501
+    )
+
+    v = graph.expand_dims(a, (1, 2))
+    assert str(v) == f"n{v.id} = graph.expand_dims(node=n{a.id}, axis=(1, 2), name='')"
+
+    w = graph.squeeze(a, (1, 2))
+    assert str(w) == f"n{w.id} = graph.squeeze(node=n{a.id}, axis=(1, 2), name='')"
+
+    x = graph.project_using_sum(a, (1, 2))
+    assert str(x) == f"n{x.id} = graph.project_using_sum(node=n{a.id}, axis=(1, 2), name='')"
+
+    y = graph.project_using_mean(a, (1, 2))
+    assert str(y) == f"n{y.id} = graph.project_using_mean(node=n{a.id}, axis=(1, 2), name='')"

--- a/tests/dt_model/engine/frontend/test_graph.py
+++ b/tests/dt_model/engine/frontend/test_graph.py
@@ -527,10 +527,10 @@ def test_repr():
 
     other_cond = graph.placeholder("other_cond")
     defval = graph.placeholder("defval")
-    u = graph.multi_clause_where([(condition, a), (other_cond, b)], defval)
+    uu = graph.multi_clause_where([(condition, a), (other_cond, b)], defval)
     assert (
-        str(u)
-        == f"n{u.id} = graph.multi_clause_where(clauses=[(n{condition.id}, n{a.id}), (n{other_cond.id}, n{b.id})], default_value=n{defval.id}, name='')"  # noqa: E501
+        str(uu)
+        == f"n{uu.id} = graph.multi_clause_where(clauses=[(n{condition.id}, n{a.id}), (n{other_cond.id}, n{b.id})], default_value=n{defval.id}, name='')"  # noqa: E501
     )
 
     v = graph.expand_dims(a, (1, 2))


### PR DESCRIPTION
This diff extends `graph.py` such that the `__repr__` of each `Node` is its own round-trippable SSA.

Part of https://github.com/fbk-most/civic-digital-twins/issues/58.