### PR TITLE
feat(linearize.py): stop visiting at boundary

### DIFF
--- a/civic_digital_twins/dt_model/engine/frontend/linearize.py
+++ b/civic_digital_twins/dt_model/engine/frontend/linearize.py
@@ -34,21 +34,24 @@ from __future__ import annotations
 from . import graph
 
 
-def forest(*roots: graph.Node) -> list[graph.Node]:
+def forest(*roots: graph.Node, boundary: set[graph.Node] | None = None) -> list[graph.Node]:
     """
-    Linearize a computation forest (multiple output nodes) into an execution plan.
+    Linearize a computation forest (multiple output nodes) into a sequence.
 
-    The nodes passed to this function are called "roots" because (1) they
-    represent the nodes you'd like to evaluate and (2) these nodes are
-    typically the final results of the computation, which should not depend
-    on any other nodes. We start linearization from such root nodes and
-    work backwards to schedule all dependencies in order. That said, it's
-    possible to apply this algorithm to any node within your graph. The
-    result would be the linear scheduling from such node's point of view.
+    The computation forest is an overlay abstraction created over a DAG where the
+    given roots identify each tree within the forest itself.
+
+    While the roots are typically the outputs computed by the DAG, they
+    can actually be any node within the DAG itself.
+
+    Evaluating the returned nodes in order ensures that you always evaluate
+    node A before node B when node B depends on node A.
 
     Args:
         *roots: the nodes to start the linearization process from. Use the
             unpacking operator `*` to pass a list of nodes.
+
+        boundary: stop visiting when reaching nodes in the boundary set.
 
     Returns
     -------
@@ -86,6 +89,9 @@ def forest(*roots: graph.Node) -> list[graph.Node]:
     # visited caches the nodes we've already visited
     visited: set[graph.Node] = set()
 
+    # ensure the boundary is not none to simplify the check below
+    boundary = boundary if boundary is not None else set()
+
     def _visit(node: graph.Node) -> None:
         # Ensure we only visit a node at most once
         if node in visited:
@@ -100,12 +106,14 @@ def forest(*roots: graph.Node) -> list[graph.Node]:
         # Register that we're visiting this node
         visiting.add(node)
 
-        # Get dependent nodes based on this node's type
-        deps = _get_dependencies(node)
+        # Stop recursing when we reach the boundary
+        if node not in boundary:
+            # Get dependent nodes based on this node's type
+            deps = _get_dependencies(node)
 
-        # Visit all dependencies first
-        for dep in deps:
-            _visit(dep)
+            # Visit all dependencies first
+            for dep in deps:
+                _visit(dep)
 
         # We are not visiting this node anymore
         visiting.remove(node)

--- a/tests/dt_model/engine/frontend/test_linearize.py
+++ b/tests/dt_model/engine/frontend/test_linearize.py
@@ -7,7 +7,7 @@ import pytest
 from civic_digital_twins.dt_model.engine.frontend import graph, linearize
 
 
-def find_node(plan, target_node):
+def find_node_idx(plan, target_node):
     """Find the index of a node in the plan using identity comparison.
 
     We MUST use this method for finding the nodes because nodes override
@@ -32,8 +32,8 @@ def test_simple_chain():
     assert len(plan) == 5
 
     # Check node order - dependencies should come before dependents
-    assert find_node(plan, a) < find_node(plan, b)
-    assert find_node(plan, b) < find_node(plan, c)
+    assert find_node_idx(plan, a) < find_node_idx(plan, b)
+    assert find_node_idx(plan, b) < find_node_idx(plan, c)
 
     # All nodes should be in the plan
     assert set(n.id for n in plan) == set(n.id for n in {a, b, c, b.right, c.right})
@@ -52,12 +52,12 @@ def test_diamond_graph():
     assert len(plan) == 6
 
     # x should come before both branches
-    assert find_node(plan, x) < find_node(plan, left_branch)
-    assert find_node(plan, x) < find_node(plan, right_branch)
+    assert find_node_idx(plan, x) < find_node_idx(plan, left_branch)
+    assert find_node_idx(plan, x) < find_node_idx(plan, right_branch)
 
     # Both branches should come before output
-    assert find_node(plan, left_branch) < find_node(plan, output)
-    assert find_node(plan, right_branch) < find_node(plan, output)
+    assert find_node_idx(plan, left_branch) < find_node_idx(plan, output)
+    assert find_node_idx(plan, right_branch) < find_node_idx(plan, output)
 
 
 def test_multi_output():
@@ -72,8 +72,8 @@ def test_multi_output():
     assert len(plan) == 5
 
     # Dependencies should come before dependents
-    assert find_node(plan, a) < find_node(plan, b)
-    assert find_node(plan, a) < find_node(plan, c)
+    assert find_node_idx(plan, a) < find_node_idx(plan, b)
+    assert find_node_idx(plan, a) < find_node_idx(plan, c)
 
 
 def test_shared_subgraph():
@@ -94,10 +94,10 @@ def test_shared_subgraph():
     assert len([n for n in plan if n is common]) == 1
 
     # Check dependencies
-    assert find_node(plan, a) < find_node(plan, common)
-    assert find_node(plan, b) < find_node(plan, common)
-    assert find_node(plan, common) < find_node(plan, out1)
-    assert find_node(plan, common) < find_node(plan, out2)
+    assert find_node_idx(plan, a) < find_node_idx(plan, common)
+    assert find_node_idx(plan, b) < find_node_idx(plan, common)
+    assert find_node_idx(plan, common) < find_node_idx(plan, out1)
+    assert find_node_idx(plan, common) < find_node_idx(plan, out2)
 
 
 def test_cycle_detection():
@@ -125,9 +125,9 @@ def test_conditional_nodes():
     plan = linearize.forest(where_result)
 
     # Check dependencies
-    assert find_node(plan, cond) < find_node(plan, where_result)
-    assert find_node(plan, x) < find_node(plan, where_result)
-    assert find_node(plan, y) < find_node(plan, where_result)
+    assert find_node_idx(plan, cond) < find_node_idx(plan, where_result)
+    assert find_node_idx(plan, x) < find_node_idx(plan, where_result)
+    assert find_node_idx(plan, y) < find_node_idx(plan, where_result)
 
     # Multi-clause where
     clauses = [(cond, x), (graph.less(x, y), graph.constant(1.0))]
@@ -136,9 +136,9 @@ def test_conditional_nodes():
     plan = linearize.forest(multi_where)
 
     # Check dependencies
-    assert find_node(plan, cond) < find_node(plan, multi_where)
-    assert find_node(plan, x) < find_node(plan, multi_where)
-    assert find_node(plan, y) < find_node(plan, multi_where)
+    assert find_node_idx(plan, cond) < find_node_idx(plan, multi_where)
+    assert find_node_idx(plan, x) < find_node_idx(plan, multi_where)
+    assert find_node_idx(plan, y) < find_node_idx(plan, multi_where)
 
 
 def test_complex_graph():
@@ -163,17 +163,17 @@ def test_complex_graph():
     plan = linearize.forest(h)
 
     # Check dependencies
-    assert find_node(plan, x) < find_node(plan, a)
-    assert find_node(plan, y) < find_node(plan, b)
-    assert find_node(plan, a) < find_node(plan, c)
-    assert find_node(plan, b) < find_node(plan, c)
-    assert find_node(plan, y) < find_node(plan, d)
-    assert find_node(plan, x) < find_node(plan, e)
-    assert find_node(plan, e) < find_node(plan, f)
-    assert find_node(plan, d) < find_node(plan, g)
-    assert find_node(plan, f) < find_node(plan, g)
-    assert find_node(plan, c) < find_node(plan, h)
-    assert find_node(plan, g) < find_node(plan, h)
+    assert find_node_idx(plan, x) < find_node_idx(plan, a)
+    assert find_node_idx(plan, y) < find_node_idx(plan, b)
+    assert find_node_idx(plan, a) < find_node_idx(plan, c)
+    assert find_node_idx(plan, b) < find_node_idx(plan, c)
+    assert find_node_idx(plan, y) < find_node_idx(plan, d)
+    assert find_node_idx(plan, x) < find_node_idx(plan, e)
+    assert find_node_idx(plan, e) < find_node_idx(plan, f)
+    assert find_node_idx(plan, d) < find_node_idx(plan, g)
+    assert find_node_idx(plan, f) < find_node_idx(plan, g)
+    assert find_node_idx(plan, c) < find_node_idx(plan, h)
+    assert find_node_idx(plan, g) < find_node_idx(plan, h)
 
 
 def test_axes_operations():
@@ -187,8 +187,8 @@ def test_axes_operations():
     plan = linearize.forest(reduced)
 
     # Check node ordering
-    assert find_node(plan, x) < find_node(plan, expanded)
-    assert find_node(plan, expanded) < find_node(plan, reduced)
+    assert find_node_idx(plan, x) < find_node_idx(plan, expanded)
+    assert find_node_idx(plan, expanded) < find_node_idx(plan, reduced)
 
 
 def test_multiple_independent_graphs():
@@ -204,8 +204,8 @@ def test_multiple_independent_graphs():
     # Check plan - independent graphs can be linearized in any order
     # but dependencies should still be respected
     assert len(plan) == 4
-    assert find_node(plan, a) < find_node(plan, a_result)
-    assert find_node(plan, b) < find_node(plan, b_result)
+    assert find_node_idx(plan, a) < find_node_idx(plan, a_result)
+    assert find_node_idx(plan, b) < find_node_idx(plan, b_result)
 
 
 def test_deterministic_ordering():

--- a/tests/dt_model/engine/frontend/test_linearize.py
+++ b/tests/dt_model/engine/frontend/test_linearize.py
@@ -146,18 +146,18 @@ def test_complex_graph():
     x = graph.placeholder("x")
     y = graph.placeholder("y")
 
-    # (x + 2) * (y - 1)
+    # c = (x + 2) * (y - 1)
     a = graph.add(x, graph.constant(2.0))
     b = graph.subtract(y, graph.constant(1.0))
     c = graph.multiply(a, b)
 
-    # exp(y) / log(x + 1)
+    # g = exp(y) / log(x + 1)
     d = graph.exp(y)
     e = graph.add(x, graph.constant(1.0))
     f = graph.log(e)
     g = graph.divide(d, f)
 
-    # max(c, g)
+    # h = max(c, g)
     h = graph.maximum(c, g)
 
     plan = linearize.forest(h)


### PR DESCRIPTION
By stopping the forest linearization at a given boundary, we can extract an embedded subtree from the embedded forest.

While there, tweak the docstring.

While there `s/find_node/find_node_idx/g` in tests for clarity.