### PR TITLE
feat(numpybackend): add syntactic sugar for evaluating

### DIFF
--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -214,8 +214,8 @@ def evaluate_single_tree(state: State, tree: forest.Tree) -> np.ndarray:
 def evaluate_nodes(state: State, *nodes: graph.Node) -> np.ndarray | None:
     """Evaluate a list of `graph.Node` using the current `State`.
 
-    This function is syntactic sugar for calling `evaluate` for each node in
-    the given input and then returning the final value.
+    This function is syntactic sugar for calling `evaluate_single_node` for each
+    node in the given input and then returning the final value.
 
     This function returns `None` if you do not supply any input node.
     """

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -195,11 +195,11 @@ def evaluate_trees(state: State, *trees: forest.Tree) -> np.ndarray | None:
     """Provide syntactic sugar for evaluating multiple trees."""
     rv: np.ndarray | None = None
     for tree in trees:
-        rv = evaluate_tree(state, tree)
+        rv = evaluate_single_tree(state, tree)
     return rv
 
 
-def evaluate_tree(state: State, tree: forest.Tree) -> np.ndarray:
+def evaluate_single_tree(state: State, tree: forest.Tree) -> np.ndarray:
     """Evaluate a `forest.Tree` using the current `State`.
 
     This function is syntactic sugar for calling `evaluate_nodes`
@@ -221,11 +221,11 @@ def evaluate_nodes(state: State, *nodes: graph.Node) -> np.ndarray | None:
     """
     rv: np.ndarray | None = None
     for node in nodes:
-        rv = evaluate_node(state, node)
+        rv = evaluate_single_node(state, node)
     return rv
 
 
-def evaluate_node(state: State, node: graph.Node) -> np.ndarray:
+def evaluate_single_node(state: State, node: graph.Node) -> np.ndarray:
     """Evaluate a node given the current state.
 
     This function assumes you have already linearized the graph. If this
@@ -275,7 +275,7 @@ def evaluate_node(state: State, node: graph.Node) -> np.ndarray:
     return result
 
 
-evaluate = evaluate_node
+evaluate = evaluate_single_node
 """Backward-compatible name for evaluate_node."""
 
 

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -191,6 +191,14 @@ class State:
             raise NodeValueNotFound(f"executor: node '{node.name}' has not been evaluated")
 
 
+def evaluate_trees(state: State, *trees: forest.Tree) -> np.ndarray | None:
+    """Provide syntactic sugar for evaluating multiple trees."""
+    rv: np.ndarray | None = None
+    for tree in trees:
+        rv = evaluate_tree(state, tree)
+    return rv
+
+
 def evaluate_tree(state: State, tree: forest.Tree) -> np.ndarray:
     """Evaluate a `forest.Tree` using the current `State`.
 
@@ -213,11 +221,11 @@ def evaluate_nodes(state: State, *nodes: graph.Node) -> np.ndarray | None:
     """
     rv: np.ndarray | None = None
     for node in nodes:
-        rv = evaluate(state, node)
+        rv = evaluate_node(state, node)
     return rv
 
 
-def evaluate(state: State, node: graph.Node) -> np.ndarray:
+def evaluate_node(state: State, node: graph.Node) -> np.ndarray:
     """Evaluate a node given the current state.
 
     This function assumes you have already linearized the graph. If this
@@ -265,6 +273,10 @@ def evaluate(state: State, node: graph.Node) -> np.ndarray:
 
     # 7. return the result
     return result
+
+
+evaluate = evaluate_node
+"""Backward-compatible name for evaluate_node."""
 
 
 def _eval_constant_op(state: State, node: graph.Node) -> np.ndarray:

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -23,7 +23,7 @@ from typing import (
 
 import numpy as np
 
-from ..frontend import graph
+from ..frontend import forest, graph
 from . import debug
 
 # Type aliases for operation function signatures
@@ -189,6 +189,32 @@ class State:
             return self.values[node]
         except KeyError:
             raise NodeValueNotFound(f"executor: node '{node.name}' has not been evaluated")
+
+
+def evaluate_tree(state: State, tree: forest.Tree) -> np.ndarray:
+    """Evaluate a `forest.Tree` using the current `State`.
+
+    This function is syntactic sugar for calling `evaluate_nodes`
+    for each node in the tree body.
+    """
+    assert len(tree.body) > 0
+    rv = evaluate_nodes(state, *tree.body)
+    assert rv is not None
+    return rv
+
+
+def evaluate_nodes(state: State, *nodes: graph.Node) -> np.ndarray | None:
+    """Evaluate a list of `graph.Node` using the current `State`.
+
+    This function is syntactic sugar for calling `evaluate` for each node in
+    the given input and then returning the final value.
+
+    This function returns `None` if you do not supply any input node.
+    """
+    rv: np.ndarray | None = None
+    for node in nodes:
+        rv = evaluate(state, node)
+    return rv
 
 
 def evaluate(state: State, node: graph.Node) -> np.ndarray:

--- a/civic_digital_twins/dt_model/simulation/evaluation.py
+++ b/civic_digital_twins/dt_model/simulation/evaluation.py
@@ -88,8 +88,7 @@ class Evaluation:
 
         # [eval] actually evaluate all the nodes
         state = executor.State(c_subs)
-        for node in linearize.forest(*all_nodes):
-            executor.evaluate(state, node)
+        executor.evaluate_nodes(state, *linearize.forest(*all_nodes))
 
         # [fix] Ensure that we have the correct shape for operands
         def _fix_shapes(value: np.ndarray) -> np.ndarray:

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -642,3 +642,9 @@ def test_forest_tree():
     assert np.array_equal(state.values[diff], expected_diff)
     assert np.array_equal(state.values[condition], expected_condition)
     assert np.array_equal(state.values[result], expected_result)
+
+
+def test_evaluate_nodes_empty():
+    """Ensure that evaluate_nodes returns none if passed no nodes."""
+    rv = executor.evaluate_nodes(executor.State(values={}))
+    assert rv is None

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -632,8 +632,7 @@ def test_forest_tree():
 
     # Evaluate with executor
     state = executor.State({x: x_val, y: y_val})
-    for tree in trees:
-        executor.evaluate_tree(state, tree)
+    executor.evaluate_trees(state, *trees)
 
     # Check intermediate and final results
     assert np.array_equal(state.values[x_squared], expected_x_squared)

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -599,7 +599,7 @@ def test_state_post_init_tracing(capsys):
     assert "cached: True" in output
 
 
-def test_forest_tree():
+def test_evaluate_trees_nonempty():
     """Test execution where we evaluate a forest tree."""
     # Build a more complex graph
     x = graph.placeholder("x")

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -645,6 +645,12 @@ def test_forest_tree():
 
 
 def test_evaluate_nodes_empty():
-    """Ensure that evaluate_nodes returns none if passed no nodes."""
+    """Ensure that evaluate_nodes returns None if passed no nodes."""
     rv = executor.evaluate_nodes(executor.State(values={}))
+    assert rv is None
+
+
+def test_evaluate_trees_empty():
+    """Ensure that evaluate_trees returns None if passed no trees."""
+    rv = executor.evaluate_trees(executor.State(values={}))
     assert rv is None


### PR DESCRIPTION
This diff adds syntactic sugar for evaluating a list of nodes as well as for evaluating a list of trees.

While there, rename `evaluate` to `evaluate_single_node` and add backward-compatible name alias.

While there, update the simulation layer to use `evaluate_nodes` (more compact).

No functional change.