### PR TITLE
feat(numpybackend): init flags using environment

### DIFF
--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -37,7 +37,7 @@ def from_environ(
 
         export DTMODEL_ENGINE_FLAGS=trace,break
 
-    cases this function to return:
+    causes this function to return:
 
         TRACE|BREAK
 

--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -5,8 +5,53 @@ We centralize the definition of flags to avoid defining flags into each package
 and ending up with incompatible compiler engine flags.
 """
 
+from typing import Callable
+import os
+
+
 TRACE = 1 << 0
 """Indicates that we should trace execution."""
 
 BREAK = 1 << 1
 """Indicates that we should break execution after evaluation."""
+
+_flagnames: dict[str, int] = {
+    "break": BREAK,
+    "trace": TRACE,
+}
+"""Maps the lowercase name of the flag to its value."""
+
+
+def from_environ(
+    varname: str = "DTMODEL_ENGINE_FLAGS",
+    getenv: Callable[[str], str|None] = os.getenv,
+) -> int:
+    """Read flags from a specific environment variable.
+
+    The format for the flags is the following:
+
+        <key>[,<key>,...]
+
+    where <key> is the case-insensitive name of an existing flag.
+
+    For example:
+
+        export DTMODEL_ENGINE_FLAGS=trace,break
+
+    cases this function to return:
+
+        TRACE|BREAK
+
+    Arguments
+    ---------
+    varname: the name of the environment variable (default: `DTMODEL_ENGINE_FLAGS`).
+    getenv: the function to read the environment variable (default: os.getenv).
+    """
+    flags: int = 0
+    for value in (getenv(varname) or "").split(","):
+        flags |= _flagnames.get(value.strip().lower(), 0)
+    return flags
+
+
+defaults = from_environ()
+"""Default compile flags initialized from the `DTMODEL_ENGINE_FLAGS` environment variable."""

--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -5,9 +5,8 @@ We centralize the definition of flags to avoid defining flags into each package
 and ending up with incompatible compiler engine flags.
 """
 
-from typing import Callable
 import os
-
+from typing import Callable
 
 TRACE = 1 << 0
 """Indicates that we should trace execution."""
@@ -24,7 +23,7 @@ _flagnames: dict[str, int] = {
 
 def from_environ(
     varname: str = "DTMODEL_ENGINE_FLAGS",
-    getenv: Callable[[str], str|None] = os.getenv,
+    getenv: Callable[[str], str | None] = os.getenv,
 ) -> int:
     """Read flags from a specific environment variable.
 

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -23,6 +23,7 @@ from typing import (
 
 import numpy as np
 
+from .. import compileflags
 from ..frontend import forest, graph
 from . import debug
 
@@ -151,21 +152,23 @@ class State:
     Make sure to provide values for placeholder nodes ahead of the evaluation
     by initializing the `values` dictionary accordingly.
 
-    Note that, if graph.NODE_FLAG_TRACE is set, the State will print the
+    Note that, if compileflags.TRACE is set, the State will print the
     nodes provided to the constructor in its __post_init__ method.
 
     Attributes
     ----------
         values: A dictionary caching the result of the computation.
-        flags: Bitmask containing debug flags (e.g., graph.NODE_FLAG_BREAK).
+        flags: Bitmask containing debug flags (e.g., compileflags.BREAK) set
+            by default using the `DTMODEL_ENGINE_FLAGS` environement
+            variable as documented by the `compileflags` package docs.
     """
 
     values: dict[graph.Node, np.ndarray]
-    flags: int = 0
+    flags: int = compileflags.defaults
 
     def __post_init__(self):
         """Print the placeholder values provided to the constructor."""
-        if self.flags & graph.NODE_FLAG_TRACE != 0:
+        if self.flags & compileflags.TRACE != 0:
             nodes = sorted(self.values.keys(), key=lambda n: n.id)
             for node in nodes:
                 debug.print_graph_node(node)
@@ -252,7 +255,7 @@ def evaluate_single_node(state: State, node: graph.Node) -> np.ndarray:
 
     # 2. check whether we need to trace this node
     flags = node.flags | state.flags
-    tracing = flags & graph.NODE_FLAG_TRACE
+    tracing = flags & compileflags.TRACE
     if tracing:
         debug.print_graph_node(node)
 
@@ -264,7 +267,7 @@ def evaluate_single_node(state: State, node: graph.Node) -> np.ndarray:
         debug.print_evaluated_node(result, cached=False)
 
     # 5. check whether we need to stop after evaluating this node
-    if flags & graph.NODE_FLAG_BREAK != 0:
+    if flags & compileflags.BREAK != 0:
         input("executor: press any key to continue...")
         print("")
 

--- a/tests/dt_model/engine/compileflags/__init__.py
+++ b/tests/dt_model/engine/compileflags/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the civic_digital_twins.dt_model.engine.compileflags package."""
+
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/dt_model/engine/compileflags/test_from_environ.py
+++ b/tests/dt_model/engine/compileflags/test_from_environ.py
@@ -14,7 +14,14 @@ def test_from_environ():
     )
     assert result == 0
 
-    # Test for the case where it has been set
+    # Test for the case where it has been set to a single value
+    result = compileflags.from_environ(
+        "antani",
+        lambda x: "break",
+    )
+    assert result == compileflags.BREAK
+
+    # Test for the case where it has been set to multiple values
     result = compileflags.from_environ(
         "antani",
         lambda x: "break,trace",

--- a/tests/dt_model/engine/compileflags/test_from_environ.py
+++ b/tests/dt_model/engine/compileflags/test_from_environ.py
@@ -1,0 +1,23 @@
+"""Tests for the civic_digital_twins.dt_model.engine.compileflags.from_environ func."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from civic_digital_twins.dt_model.engine import compileflags
+
+
+def test_from_environ():
+    """Tests that the from_environ function works as intended."""
+
+    # Test for the case where the environment variable has not been set
+    result = compileflags.from_environ(
+        "antani",
+        lambda x: None,
+    )
+    assert result == 0
+
+    # Test for the case where it has been set
+    result = compileflags.from_environ(
+        "antani",
+        lambda x: "break,trace",
+    )
+    assert result == compileflags.BREAK|compileflags.TRACE

--- a/tests/dt_model/engine/compileflags/test_from_environ.py
+++ b/tests/dt_model/engine/compileflags/test_from_environ.py
@@ -7,7 +7,6 @@ from civic_digital_twins.dt_model.engine import compileflags
 
 def test_from_environ():
     """Tests that the from_environ function works as intended."""
-
     # Test for the case where the environment variable has not been set
     result = compileflags.from_environ(
         "antani",
@@ -20,4 +19,4 @@ def test_from_environ():
         "antani",
         lambda x: "break,trace",
     )
-    assert result == compileflags.BREAK|compileflags.TRACE
+    assert result == compileflags.BREAK | compileflags.TRACE

--- a/tests/dt_model/engine/frontend/test_graph.py
+++ b/tests/dt_model/engine/frontend/test_graph.py
@@ -5,6 +5,7 @@
 import subprocess
 import textwrap
 
+from civic_digital_twins.dt_model.engine import compileflags
 from civic_digital_twins.dt_model.engine.frontend import graph
 
 
@@ -44,13 +45,13 @@ def test_debug_flags():
 
     # Test tracepoint
     traced = graph.tracepoint(a)
-    assert traced.flags & graph.NODE_FLAG_TRACE
+    assert traced.flags & compileflags.TRACE
     assert traced is a  # Should return same node
 
     # Test breakpoint
     broken = graph.breakpoint(a)
-    assert broken.flags & graph.NODE_FLAG_BREAK
-    assert broken.flags & graph.NODE_FLAG_TRACE
+    assert broken.flags & compileflags.BREAK
+    assert broken.flags & compileflags.TRACE
     assert broken is a  # Should return same node
 
 

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -5,6 +5,7 @@
 import numpy as np
 import pytest
 
+from civic_digital_twins.dt_model.engine import compileflags
 from civic_digital_twins.dt_model.engine.frontend import forest, graph, linearize
 from civic_digital_twins.dt_model.engine.numpybackend import executor
 
@@ -236,7 +237,7 @@ def test_debug_flags(capsys, monkeypatch):
     z = graph.add(x, graph.constant(5.0))
     plan = linearize.forest(z)
 
-    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=graph.NODE_FLAG_TRACE)
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=compileflags.TRACE)
     executor.evaluate_nodes(state, *plan)
 
     captured = capsys.readouterr()
@@ -247,7 +248,7 @@ def test_debug_flags(capsys, monkeypatch):
     named_node.name = "named_addition"
     plan = linearize.forest(named_node)
 
-    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=graph.NODE_FLAG_BREAK)
+    state = executor.State({x: np.array([1.0, 2.0, 3.0])}, flags=compileflags.BREAK)
     executor.evaluate_nodes(state, *plan)
 
     # Check that input was called (breakpoint triggered)
@@ -583,15 +584,15 @@ def test_state_post_init_tracing(capsys):
     y_val = np.array([4.0, 5.0, 6.0])
 
     # Create state with tracing flag
-    executor.State({x: x_val, y: y_val}, flags=graph.NODE_FLAG_TRACE)
+    executor.State({x: x_val, y: y_val}, flags=compileflags.TRACE)
 
     # Check that tracing output was generated during initialization
     captured = capsys.readouterr()
     output = captured.out
 
     # Verify that both nodes were traced in the output
-    assert f"name: {x.name}" in output
-    assert f"name: {y.name}" in output
+    assert f"node: {x}" in output
+    assert f"node: {y}" in output
     assert "=== begin tracepoint ===" in output
 
     # Verify the cached indication is shown

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -591,8 +591,8 @@ def test_state_post_init_tracing(capsys):
     output = captured.out
 
     # Verify that both nodes were traced in the output
-    assert f"node: {x}" in output
-    assert f"node: {y}" in output
+    assert f"name: {x.name}" in output
+    assert f"name: {y.name}" in output
     assert "=== begin tracepoint ===" in output
 
     # Verify the cached indication is shown


### PR DESCRIPTION
This diff allows the user to initialize the compile flags using the `DTMODEL_ENGINE_FLAGS` environment variable.

This feature allows one to easily tweak the compiler flags behavior, mainly for debugging purposes.

Part of https://github.com/fbk-most/civic-digital-twins/issues/58: we are making models easier to debug.