### PR TITLE
feat: implement the DUMP flag

### DIFF
--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -14,8 +14,12 @@ TRACE = 1 << 0
 BREAK = 1 << 1
 """Indicates that we should break execution after evaluation."""
 
+DUMP = 1 << 2
+"""Dump nodes in SSA format ahead of evaluation."""
+
 _flagnames: dict[str, int] = {
     "break": BREAK,
+    "dump": DUMP,
     "trace": TRACE,
 }
 """Maps the lowercase name of the flag to its value."""

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -208,9 +208,23 @@ def evaluate_single_tree(state: State, tree: forest.Tree) -> np.ndarray:
     This function is syntactic sugar for calling `evaluate_nodes`
     for each node in the tree body.
     """
+    # Ensure the invariant for the tree applies
     assert len(tree.body) > 0
-    rv = evaluate_nodes(state, *tree.body)
+
+    # Honor the dump flag if requested to dump the code
+    if state.flags & compileflags.DUMP != 0:
+        print("=== begin tree dump ===")
+        print(str(tree))
+        print("=== end tree dump ===")
+        print("")
+
+    # Evaluate the tree body
+    rv = _evaluate_nodes(state, *tree.body)
+
+    # Ensure the invariant holds for the result
     assert rv is not None
+
+    # Return result to the caller
     return rv
 
 
@@ -222,6 +236,19 @@ def evaluate_nodes(state: State, *nodes: graph.Node) -> np.ndarray | None:
 
     This function returns `None` if you do not supply any input node.
     """
+    # Honor the DUMP flag when requested to do so
+    if state.flags & compileflags.DUMP != 0:
+        print("=== begin nodes dump ===")
+        for node in nodes:
+            print(str(node))
+        print("=== end nodes dump ===")
+        print("")
+
+    # Defer to the internal nodes evaluator
+    return _evaluate_nodes(state, *nodes)
+
+
+def _evaluate_nodes(state: State, *nodes: graph.Node) -> np.ndarray | None:
     rv: np.ndarray | None = None
     for node in nodes:
         rv = evaluate_single_node(state, node)

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -191,8 +191,8 @@ def test_complex_graph():
     expected_condition = x_val > y_val
     expected_result = np.where(expected_condition, expected_sum, expected_diff)
 
-    # Evaluate with executor
-    state = executor.State({x: x_val, y: y_val})
+    # Evaluate with executor setting the DUMP flag to exercise it
+    state = executor.State({x: x_val, y: y_val}, flags=compileflags.DUMP)
     executor.evaluate_nodes(state, *plan)
 
     # Check intermediate and final results
@@ -630,8 +630,8 @@ def test_evaluate_trees_nonempty():
     expected_condition = x_val > y_val
     expected_result = np.where(expected_condition, expected_sum, expected_diff)
 
-    # Evaluate with executor
-    state = executor.State({x: x_val, y: y_val})
+    # Evaluate with executor setting the DUMP flag to exercise it
+    state = executor.State({x: x_val, y: y_val}, flags=compileflags.DUMP)
     executor.evaluate_trees(state, *trees)
 
     # Check intermediate and final results


### PR DESCRIPTION
When the DUMP flag is set, we dump nodes in SSA format ahead of evaluating a list of nodes or a tree.

This is part of https://github.com/fbk-most/civic-digital-twins/issues/58 and helps to improve the DX story by showing the code we're running.