### PR TITLE
feat(graph): allow setting node name if not set

### DIFF
--- a/civic_digital_twins/dt_model/engine/frontend/graph.py
+++ b/civic_digital_twins/dt_model/engine/frontend/graph.py
@@ -225,6 +225,10 @@ class Node(Generic[T]):
         self.flags = 0
         self.id = _id_generator.add(1)
 
+    def maybe_set_name(self, name: str) -> None:
+        """Set the node name unless it has already been set."""
+        self.name = self.name if self.name else name
+
     def __str__(self) -> str:
         """Return a round-trippable SSA representation of the node."""
         return repr(self)  # subclasses define suitable __repr__

--- a/tests/dt_model/engine/frontend/test_graph.py
+++ b/tests/dt_model/engine/frontend/test_graph.py
@@ -545,3 +545,17 @@ def test_repr():
 
     y = graph.project_using_mean(a, (1, 2))
     assert str(y) == f"n{y.id} = graph.project_using_mean(node=n{a.id}, axis=(1, 2), name='')"
+
+
+def test_maybe_set_name():
+    """Ensure that Node.maybe_set_name works as intended."""
+
+    # When there is already a name
+    n1 = graph.placeholder("a")
+    n1.maybe_set_name("x")
+    assert n1.name == "a"
+
+    # When there is no name
+    n2 = graph.constant(177114)
+    n2.maybe_set_name("x")
+    assert n2.name == "x"


### PR DESCRIPTION
Empirical experience trying to debug the produced models suggests that being able to set the name of a node if not already set is a good primitive for assigning a name to constraints usages. Sure, we're losing a bit of purity, but the DX is better.

Part of https://github.com/fbk-most/civic-digital-twins/issues/58