### PR TITLE
fix(numpybackend)!: distinguish placeholder tracing

### DIFF
--- a/civic_digital_twins/dt_model/engine/numpybackend/debug.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/debug.py
@@ -5,19 +5,19 @@ import numpy as np
 from ..frontend import graph, pretty
 
 
-def print_graph_node(node: graph.Node) -> None:
+def print_graph_node(node: graph.Node, context: str = "tracepoint") -> None:
     """Print a node within the computation graph."""
-    print("=== begin tracepoint ===")
+    print(f"=== begin {context} ===")
     print(f"name: {node.name}")
     print(f"id: {node.id}")
     print(f"type: {node.__class__}")
     print(f"formula: {pretty.format(node)}")
 
 
-def print_evaluated_node(value: np.ndarray, cached: bool = False) -> None:
+def print_evaluated_node(value: np.ndarray, cached: bool = False, context: str = "tracepoint") -> None:
     """Print a node after evaluation."""
     print(f"shape: {value.shape}")
     print(f"cached: {cached}")
     print(f"value:\n{value}")
-    print("=== end tracepoint ===")
+    print(f"=== end {context} ===")
     print("")

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -153,7 +153,8 @@ class State:
     by initializing the `values` dictionary accordingly.
 
     Note that, if compileflags.TRACE is set, the State will print the
-    nodes provided to the constructor in its __post_init__ method.
+    nodes provided to the constructor in its __post_init__ method using
+    the `=== begin/end placeholder ===' markers.
 
     Attributes
     ----------
@@ -171,8 +172,8 @@ class State:
         if self.flags & compileflags.TRACE != 0:
             nodes = sorted(self.values.keys(), key=lambda n: n.id)
             for node in nodes:
-                debug.print_graph_node(node)
-                debug.print_evaluated_node(self.values[node], cached=True)
+                debug.print_graph_node(node, context="placeholder")
+                debug.print_evaluated_node(self.values[node], cached=True, context="placeholder")
 
     def get_node_value(self, node: graph.Node) -> np.ndarray:
         """Access the value associated with a node.

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -593,7 +593,7 @@ def test_state_post_init_tracing(capsys):
     # Verify that both nodes were traced in the output
     assert f"name: {x.name}" in output
     assert f"name: {y.name}" in output
-    assert "=== begin tracepoint ===" in output
+    assert "=== begin placeholder ===" in output
 
     # Verify the cached indication is shown
     assert "cached: True" in output


### PR DESCRIPTION
I find it confusing that placeholder tracing produces the same output produced by ordinary node tracing.

Let us instead distinguish them for clarity.

Part of https://github.com/fbk-most/civic-digital-twins/issues/58.

BREAKING CHANGE: the output produced by placeholder tracing now is like `=== begin/end placeholder ===` while previously it was instead like `=== begin/end tracepoint ===`.