### PR TITLE
fix(dt_model): make debug output easier to understand

### DIFF
--- a/civic_digital_twins/dt_model/internal/sympyke/symbol.py
+++ b/civic_digital_twins/dt_model/internal/sympyke/symbol.py
@@ -17,6 +17,14 @@ class SymbolValue:
     node: graph.placeholder
     name: str
 
+    def __str__(self) -> str:
+        """Return a string representation of the symbol."""
+        return repr(self)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the symbol."""
+        return f"'{self.name}'"
+
 
 class _SymbolTable:
     def __init__(self):

--- a/civic_digital_twins/dt_model/symbols/constraint.py
+++ b/civic_digital_twins/dt_model/symbols/constraint.py
@@ -27,6 +27,9 @@ class Constraint:
         capacity: Index,
         name: str = "",
     ) -> None:
-        self.usage = SymIndex(name="", value=usage)
+        # TODO(bassosimone): for debuggability, assign the index name
+        # to be f'{name}_usage` rather than just f'{name}'. Figure out
+        # whether this is the desired outcome or not.
+        self.usage = SymIndex(name=name + "_usage", value=usage)
         self.capacity = capacity
         self.name = name

--- a/civic_digital_twins/dt_model/symbols/index.py
+++ b/civic_digital_twins/dt_model/symbols/index.py
@@ -75,7 +75,11 @@ class Index:
 
         # Otherwise, it's just a reference to an existing node (which
         # typically is the result of defining a formula).
+        #
+        # For debuggability, let's assign the name to the node if it
+        # has not been already set by previous code.
         elif value is not None:
+            value.maybe_set_name(name)
             self.value = value
             self.node = value
 


### PR DESCRIPTION
This diff includes several small changes meant to make the debug output easier to understand for a developer. Namely:

1. Represent symbol values as string, which intuitively makes sense and reduces the cognitive load of reading the logs.

2. Automatically assign a name to SymIndex nodes if it was not already set, which helps to link nodes to the model.

3. Specifically, assign `f'{name}_usage'` to the constraint usage. This is one of the most important indexes and it's really helpful to locate it inside the code dump and the code execution logs.

With these changes implemented, I think I have done enough for making the overal debugging story better for now.

Closes https://github.com/fbk-most/civic-digital-twins/issues/58