### PR TITLE
fix(forest): add constants as deps

### DIFF
--- a/civic_digital_twins/dt_model/engine/frontend/forest.py
+++ b/civic_digital_twins/dt_model/engine/frontend/forest.py
@@ -115,7 +115,10 @@ def partition(*roots: graph.Node) -> list[Tree]:
 
         # 5.2. check whether all dependencies are satisfied skipping the
         # placeholders since they're satisfied by definition
-        satisfied = all(dep in processed if not isinstance(dep, graph.placeholder) else True for dep in tree.inputs)
+        satisfied = all(
+            dep in processed if not isinstance(dep, (graph.placeholder, graph.constant)) else True
+            for dep in tree.inputs
+        )
 
         # 5.3. if not, put the tree at the back.
         #
@@ -157,9 +160,10 @@ def _partition(*roots: graph.Node) -> list[Tree]:
         # 3.4. prepare the collect the "body"
         body: list[graph.Node] = []
 
-        # 3.5. distinguish between inputs and "body"
+        # 3.5. distinguish between inputs and "body" ensuring that
+        # placeholders and constants are considered inputs.
         for node in allnodes:
-            if node in boundary:
+            if node in boundary or isinstance(node, (graph.placeholder, graph.constant)):
                 unique_inputs.add(node)
                 continue
             body.append(node)

--- a/civic_digital_twins/dt_model/engine/frontend/forest.py
+++ b/civic_digital_twins/dt_model/engine/frontend/forest.py
@@ -114,7 +114,7 @@ def partition(*roots: graph.Node) -> list[Tree]:
         tree = work.popleft()
 
         # 5.2. check whether all dependencies are satisfied skipping the
-        # placeholders since they're satisfied by definition
+        # placeholders and constants since they're satisfied by definition
         satisfied = all(
             dep in processed if not isinstance(dep, (graph.placeholder, graph.constant)) else True
             for dep in tree.inputs

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -263,6 +263,14 @@ def evaluate_single_tree(state: State, tree: forest.Tree) -> np.ndarray:
         print("=== end tree dump ===")
         print("")
 
+    # Ensure that every constant within the tree input has already
+    # been evaluated and otherwise evaluate it once. This is required
+    # because constants are part of the tree input set. Also, remember
+    # that evaluate_single_node evaluates each node at most once.
+    for node in tree.inputs:
+        if isinstance(node, graph.constant):
+            evaluate_single_node(state, node)
+
     # Evaluate the tree body
     rv = _evaluate_nodes(state, *tree.body)
 

--- a/tests/dt_model/engine/frontend/test_forest.py
+++ b/tests/dt_model/engine/frontend/test_forest.py
@@ -44,10 +44,8 @@ def test_partition():
     assert trees[2].root() is h
 
     # Ensure that the string representation is correct
-    expect = f"""def t{g.id}(n{c.id}: graph.Node) -> graph.Node:
-    n{y.id} = graph.placeholder(name='y', default_value=None)
+    expect = f"""def t{g.id}(n{y.id}: graph.Node, n{k1.id}: graph.Node, n{c.id}: graph.Node) -> graph.Node:
     n{d.id} = graph.exp(node=n{y.id}, name='d')
-    n{k1.id} = graph.constant(value=1.0, name='k1')
     n{e.id} = graph.add(left=n{c.id}, right=n{k1.id}, name='e')
     n{f.id} = graph.log(node=n{e.id}, name='f')
     n{g.id} = graph.divide(left=n{d.id}, right=n{f.id}, name='g')


### PR DESCRIPTION
One of the goals of producing a forest is to isolate a subtree and explicitly name all the leaves it depends on. In terms of potentially generating code using Numba (as described in the https://github.com/fbk-most/civic-digital-twins/issues/54 issue), this design is optimal, because it allows to neatly separate the algorithm proper and its dependencies. Beyond Numba, with this change, we also get easier to understand code where we do not instantiate the same constants over and over again. As such, with this change we also improve the debuggability of the engine as documented by https://github.com/fbk-most/civic-digital-twins/issues/58.