### PR TITLE
feat(numpybackend): dump round-tripping code

### DIFF
--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -131,7 +131,7 @@ Add entries to this table to support more axis operations."""
 
 
 def _is_immediate(node: graph.Node) -> bool:
-    """Return whether the node is an immediate or needs to be evaluate.
+    """Return whether the node is an immediate or needs to be evaluated.
 
     An immediate node is a node whose value is known ahead of
     evaluation. Currently, this means placeholder or constant nodes.

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -164,6 +164,9 @@ def _print_evaluated_node(node: graph.Node, value: np.ndarray, cached: bool = Fa
         print(f"# dtype: {value.dtype}")
 
     # 3. print whether the node was read from the cache.
+    #
+    # TODO(bassosimone): this attribute is a leftover of when we were
+    # evaluating the tree directly and less meaningful now.
     print(f"# cached: {cached}")
 
     # 4. give the user a sense of the node value for debugging purposes

--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -14,6 +14,7 @@ The executor expects all placeholder values to be provided in the initial
 state and evaluates each node exactly once, storing results for later reuse.
 """
 
+import ast
 from dataclasses import dataclass, field
 from typing import (
     Callable,
@@ -27,6 +28,7 @@ import numpy as np
 
 from .. import compileflags
 from ..frontend import forest, graph, ir
+from . import jit
 
 # Type aliases for operation function signatures
 _BinaryOpFunc: TypeAlias = Callable[[np.ndarray, np.ndarray], np.ndarray]
@@ -129,18 +131,53 @@ along the specified axis.
 Add entries to this table to support more axis operations."""
 
 
-def _print_graph_node(node: graph.Node, context: str = "tracepoint") -> None:
-    """Print a node within the computation graph."""
-    print(f"=== begin {context} ===")
-    print(f"node: {str(node)}")
+def _is_immediate(node: graph.Node) -> bool:
+    """Return whether the node is an immediate or needs to be evaluate.
+
+    An immediate node is a node whose value is known ahead of
+    evaluation. Currently, this means placeholder or constant nodes.
+    """
+    return isinstance(node, (graph.constant, graph.placeholder))
 
 
-def _print_evaluated_node(value: np.ndarray, cached: bool = False, context: str = "tracepoint") -> None:
+def _print_graph_node(node: graph.Node) -> None:
+    """Print a node before evaluation."""
+    # 1. print the original DAG node as a comment so we can always
+    # understand what is the specific node leading to this.
+    print(f"# {str(node)}")
+
+    # 2. print the numpy equivalent for non-immediate nodes such
+    # that we can round-trip the representation.
+    if not _is_immediate(node):
+        print(ast.unparse(jit.graph_node_to_ast_stmt(node, None)))
+
+
+def _print_evaluated_node(node: graph.Node, value: np.ndarray, cached: bool = False) -> None:
     """Print a node after evaluation."""
-    print(f"shape: {value.shape}")
-    print(f"cached: {cached}")
-    print(f"value:\n{value}")
-    print(f"=== end {context} ===")
+    # Throughout this function we try to be very defensive with respect
+    # to the node operations. Sometimes, numba returns bare floats rather
+    # then `np.ndarray` and this only happens at runtime. This paranoia
+    # does not apply to placeholders and constants, which we provide.
+
+    # 1. for nodes that are not evaluated, we print their actual
+    # value so the representation can round trip.
+    if _is_immediate(node):
+        print(ast.unparse(jit.graph_node_to_ast_stmt(node, value)))
+
+    # 2. print the shape and dtype, which are invaluable when debugging
+    if hasattr(value, "shape"):
+        print(f"# shape: {value.shape}")
+    if hasattr(value, "dtype"):
+        print(f"# dtype: {value.dtype}")
+
+    # 3. print whether the node was read from the cache.
+    print(f"# cached: {cached}")
+
+    # 4. give the user a sense of the node value for debugging purposes
+    print("# value:")
+    print("\n".join("# " + line for line in str(value).splitlines()))
+
+    # 5. add an empty line, which is always nice to separate things
     print("")
 
 
@@ -215,9 +252,10 @@ class State:
         """Print the placeholder values provided to the constructor."""
         if self.flags & compileflags.TRACE != 0:
             nodes = sorted(self.values.keys(), key=lambda n: n.id)
-            for node in nodes:
-                _print_graph_node(node, context="placeholder")
-                _print_evaluated_node(self.values[node], cached=True, context="placeholder")
+            if nodes:
+                for node in nodes:
+                    _print_graph_node(node)
+                    _print_evaluated_node(node, self.values[node], cached=True)
 
     def get_node_value(self, node: graph.Node) -> np.ndarray:
         """Access the value associated with a node.
@@ -372,11 +410,11 @@ def evaluate_single_node(state: State, node: graph.Node) -> np.ndarray:
 
     # 4. check whether we need to print the computation result
     if tracing:
-        _print_evaluated_node(result, cached=False)
+        _print_evaluated_node(node, result, cached=False)
 
     # 5. check whether we need to stop after evaluating this node
     if flags & compileflags.BREAK != 0:
-        input("executor: press any key to continue...")
+        input("# executor: press any key to continue...")
         print("")
 
     # 6. store the node result in the state

--- a/civic_digital_twins/dt_model/engine/numpybackend/jit.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/jit.py
@@ -1,0 +1,153 @@
+"""NumPy JIT compiler infrastructure.
+
+This module provides support for:
+
+1. transforming graph.Node, forest.Tree, and ir.DAG into a Python AST
+that uses NumPy function calls (e.g., `graph.add` -> `np.add`).
+
+2. compiling the Python AST to Python bytecode.
+
+3. JIT compiling the Python bytecode using Numba.
+
+This code is still experimental and also incomplete. For now, we only
+implement the bare minimum to pretty print nodes for debugging.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+
+import numpy as np
+
+from ..frontend import graph
+
+
+class UnsupportedNodeType(Exception):
+    """Raised when the executor encounters an unsupported node type."""
+
+
+class UnsupportedOperation(Exception):
+    """Raised when the executor encounters an unsupported operation."""
+
+
+_operation_names: dict[type[graph.Node], str] = {
+    # placeholder
+    graph.placeholder: "asarray",
+    # constant
+    graph.constant: "asarray",
+    # binary
+    graph.add: "add",
+    graph.subtract: "subtract",
+    graph.multiply: "multiply",
+    graph.divide: "divide",
+    graph.equal: "equal",
+    graph.not_equal: "not_equal",
+    graph.less: "less",
+    graph.less_equal: "less_equal",
+    graph.greater: "greater",
+    graph.greater_equal: "greater_equal",
+    graph.logical_and: "logical_and",
+    graph.logical_or: "logical_or",
+    graph.logical_xor: "logical_xor",
+    graph.power: "power",
+    graph.maximum: "maximum",
+    # unary
+    graph.logical_not: "logical_not",
+    graph.exp: "exp",
+    graph.log: "log",
+    # where
+    graph.multi_clause_where: "select",
+    graph.where: "where",
+    # axis operations
+    graph.expand_dims: "expand_dims",
+    graph.reduce_sum: "sum",
+    graph.reduce_mean: "mean",
+}
+
+
+def _node_name(node: graph.Node) -> str:
+    return f"n{node.id}"
+
+
+def _np_attr_name(name: str) -> ast.expr:
+    return ast.Attribute(value=ast.Name(id="np", ctx=ast.Load()), attr=name, ctx=ast.Load())
+
+
+def _axis_as_tuple(axis: graph.Axis) -> tuple[int, ...]:
+    return (axis,) if isinstance(axis, int) else axis
+
+
+def _np_ndarray_to_ast_expr(value: graph.Scalar | list) -> ast.expr:
+    if isinstance(value, list):
+        return ast.List(elts=[_np_ndarray_to_ast_expr(v) for v in value], ctx=ast.Load())
+    else:
+        return ast.Constant(value=value)
+
+
+def graph_node_to_ast_stmt(node: graph.Node, value: np.ndarray | None) -> ast.stmt:
+    """Transform a graph.Node to a Python ast.expr."""
+    # 2. get the operation name
+    try:
+        opname = _operation_names[type(node)]
+    except KeyError:
+        raise UnsupportedOperation(f"jit: unsupported operation: {type(node)}")
+
+    # 3. prepare for args and kwargs
+    posargs: list[ast.expr] = []
+    kwargs: list[ast.keyword] = []
+
+    # 4. evaluate placeholders
+    if isinstance(node, graph.placeholder):
+        assert value is not None
+        posargs.append(_np_ndarray_to_ast_expr(value.tolist()))
+
+    # 5. evaluate constants
+    elif isinstance(node, graph.constant):
+        posargs.append(ast.Constant(value=node.value))
+
+    # 6. evaluate unary operations
+    elif isinstance(node, graph.UnaryOp):
+        posargs.append(ast.Name(id=_node_name(node.node), ctx=ast.Load()))
+
+    # 7. evaluate binary operations
+    elif isinstance(node, graph.BinaryOp):
+        posargs.append(ast.Name(id=_node_name(node.left), ctx=ast.Load()))
+        posargs.append(ast.Name(id=_node_name(node.right), ctx=ast.Load()))
+
+    # 8. evaluate where operations
+    elif isinstance(node, graph.where):
+        posargs.append(ast.Name(id=_node_name(node.condition), ctx=ast.Load()))
+        posargs.append(ast.Name(id=_node_name(node.then), ctx=ast.Load()))
+        posargs.append(ast.Name(id=_node_name(node.otherwise), ctx=ast.Load()))
+
+    # 9. evaluate multi_clause_where
+    elif isinstance(node, graph.multi_clause_where):
+        condlist: list[ast.expr] = []
+        choicelist: list[ast.expr] = []
+        for cond, choice in node.clauses:
+            condlist.append(ast.Name(id=_node_name(cond), ctx=ast.Load()))
+            choicelist.append(ast.Name(id=_node_name(choice), ctx=ast.Load()))
+        default: ast.expr = ast.Name(id=_node_name(node.default_value), ctx=ast.Load())
+        posargs.extend([ast.List(condlist), ast.List(choicelist), default])
+
+    # 10. evaluate axis operations
+    elif isinstance(node, graph.AxisOp):
+        posargs.append(ast.Name(id=_node_name(node.node), ctx=ast.Load()))
+        kwargs.append(ast.keyword("axis", ast.Tuple(elts=[ast.Constant(value=x) for x in _axis_as_tuple(node.axis)])))
+
+    # 11. catch all for not implemented operations
+    else:
+        raise UnsupportedNodeType(f"jit: unsupported node type: {type(node)}")
+
+    # 12. create function call expr
+    expr = ast.Call(func=_np_attr_name(opname), args=posargs, keywords=kwargs)
+
+    # 13. assign the result of the function call
+    assign = ast.Assign(
+        targets=[ast.Name(id=_node_name(node), ctx=ast.Store())],
+        value=expr,
+    )
+
+    # 14. Fixup the resulting piece of AST recursively
+    ast.fix_missing_locations(assign)
+    return assign


### PR DESCRIPTION
This diff ensures the numpybackend emits round-tripping, valid NumPy code. In other words, the debugging trace produced by a model is itself a re-runnable, concrete model (save for the need to add `import numpy as np` at the top of the generated trace, which is a minor issue IMHO).

I suspect this is the maximum debugging and transparency level to which we can get in this short period of time.

I added some supporting code to `jit.py` since the functionality we're using for debugging is the same we'd need to implement a JIT. Specifically, I added the functionality to transform a graph.Node to the corresponding Python AST expression, which is also the basic building block required to implement JIT coding with Numba.

Part of https://github.com/fbk-most/civic-digital-twins/issues/58.