### PR TITLE
numpybackend: cleanup cached and fix DUMP

### DIFF
--- a/civic_digital_twins/dt_model/engine/compileflags/__init__.py
+++ b/civic_digital_twins/dt_model/engine/compileflags/__init__.py
@@ -9,13 +9,24 @@ import os
 from typing import Callable
 
 TRACE = 1 << 0
-"""Indicates that we should trace execution."""
+"""Indicates that we should trace execution.
+
+Specifically, tracing execution means printing the equivalent backend
+code that is being executed in SSA form along with contextual info.
+
+Note that this flag does not mix well with DUMP since both emit
+valid Python code using the same names.
+"""
 
 BREAK = 1 << 1
 """Indicates that we should break execution after evaluation."""
 
 DUMP = 1 << 2
-"""Dump nodes in SSA format ahead of evaluation."""
+"""Dump nodes in SSA format ahead of evaluation.
+
+Note that this flag does not mix well with TRACE since both emit
+valid Python code using the same names.
+"""
 
 _flagnames: dict[str, int] = {
     "break": BREAK,

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -600,9 +600,6 @@ def test_state_post_init_tracing(capsys):
     assert f"# n{y.id} = graph.placeholder(name='y', default_value=None)" in output
     assert f"n{y.id} = np.asarray([4.0, 5.0, 6.0])" in output
 
-    # Verify the cached indication is shown
-    assert "cached: True" in output
-
 
 def test_evaluate_trees_nonempty():
     """Test execution where we evaluate a forest tree."""


### PR DESCRIPTION
1. remove the cached information since it's useless now that we're actually using topological sorting rather than tree evaluation

2. ensure that DUMP emits valid Python code and clarify in the docs that DUMP and TRACE do not mix well together if the objective is that of obtaining valid Python code in output

Part of https://github.com/fbk-most/civic-digital-twins/issues/58.