### PR TITLE
feat(executor.State): add set_node_value

### DIFF
--- a/civic_digital_twins/dt_model/engine/numpybackend/executor.py
+++ b/civic_digital_twins/dt_model/engine/numpybackend/executor.py
@@ -266,6 +266,10 @@ class State:
         except KeyError:
             raise NodeValueNotFound(f"executor: node '{node.name}' has not been evaluated")
 
+    def set_node_value(self, node: graph.Node, value: np.ndarray) -> None:
+        """Set the value associated with the given node."""
+        self.values[node] = value
+
 
 def evaluate_dag(state: State, dag: ir.DAG) -> np.ndarray | None:
     """Evaluate a DAG IR and produce a result or nothing.

--- a/tests/dt_model/engine/numpybackend/test_executor.py
+++ b/tests/dt_model/engine/numpybackend/test_executor.py
@@ -786,3 +786,12 @@ def test_evaluate_dag_nodes():
     assert np.array_equal(state.values[diff], expected_diff)
     assert np.array_equal(state.values[condition], expected_condition)
     assert np.array_equal(state.values[result], expected_result)
+
+
+def test_state_set_node_value():
+    """Ensure we can mutate the state and set node values."""
+    state = executor.State(values={})
+    node = graph.placeholder("a")
+    value = np.zeros(10)
+    state.set_node_value(node, value)
+    assert np.all(value == state.get_node_value(node))


### PR DESCRIPTION
This diff adds the set_node_value setter to executor.State.

I realized that doing this was the correct thing to do in order to generalize over the current numpybackend API.

Spotted while working on https://github.com/fbk-most/civic-digital-twins/issues/57.